### PR TITLE
要約による中期的なコンテキストの充実

### DIFF
--- a/src/core/context_manager.py
+++ b/src/core/context_manager.py
@@ -1,25 +1,98 @@
-# src/core/context_manager.py (最終版)データベースによる時間的情報の追加2
-# (変更点は build_prompt_parts_for_command のみ)
-
 from typing import List, Dict, Optional, Any
 from PIL import Image
 
 class ContextManager:
+    """
+    【アクティブなセッション】のコンテキスト情報を一時的に保持し、
+    プロンプトを生成する役割に特化したクラス。
+    永続的なデータはDatabaseManagerが管理する。
+    """
     def __init__(self):
         self.problem_context_text: str = "まだ問題は読み込まれていません。"
         self.triggered_image: Optional[Image.Image] = None
-    def set_problem_context(self, context_text: str): self.problem_context_text = context_text if context_text else "まだ問題は読み込まれていません。"
-    def set_triggered_image(self, image: Image.Image): self.triggered_image = image
+        self.chat_summary: str = "まだ会話はありません。"
+        
+    def set_problem_context(self, context_text: str):
+        """アクティブなセッションの問題コンテキストを（メモリ上に）設定する"""
+        self.problem_context_text = context_text if context_text else "まだ問題は読み込まれていません。"
+
+    def set_triggered_image(self, image: Image.Image):
+        """トリガーの瞬間の画像を（メモリ上に）保存する"""
+        self.triggered_image = image
+
+    def set_chat_summary(self, summary: str):
+        """アクティブなセッションの会話要約を（メモリ上に）設定する"""
+        self.chat_summary = summary if summary else "まだ会話はありません。"
 
     def build_prompt_for_query(self, user_query: str, chat_history: List[Dict], monologue_history: List[str], observation_log: List[str], long_term_context: str) -> str:
+        """
+        ユーザーからの質問応答のため、DBから取得した情報と現在の状態を統合してプロンプトを生成する。
+        """
+        
         history_str = "\n".join([f"- {msg['role']}: {msg['content']}" for msg in chat_history])
         monologue_str = "\n".join([f"- {m}" for m in monologue_history]) or "なし"
         observation_str = "\n".join([f"- {o}" for o in observation_log]) or "なし"
-        return f"""あなたは、ユーザーの長期的な学習履歴も理解している、パーソナルな家庭教師AIです。\n\n# 応答形式のルール\n- 応答は必ずMarkdown形式で記述してください。\n- 見出し（`###`）、太字（`**...**`）、箇条書き（`- ...`）などを活用し、視覚的に分かりやすい説明を心がけてください。\n- **数式**は、ディスプレイ数式なら `$$ ... $$`、インライン数式なら `$...$` を使って記述してください。\n- **コードや計算過程**など、数式ではないが整形して見せたいテキストは、インラインコード（`...`）やコードブロック（```...```）を使用できます。\n- **重要:** コードブロックの中に数式を記述しないでください。数式は必ず独立させてください。\n\n# 長期的な学習状況（長期記憶）\n{long_term_context}\n\n# 現在のセッションの状況（短期記憶）\n## ユーザーが取り組んでいる問題\n{self.problem_context_text}\n## ユーザーの最近の様子（システムによる定点観測）\n{observation_str}\n## ユーザーの最近の独り言（音声認識より）\n{monologue_str}\n## 直近の会話\n{history_str}\n\n# ユーザーからの現在の質問\n「{user_query}」\n\n# あなたのタスク\n上記のすべての情報を統合し、ユーザーの思考プロセスや詰まっている点を深く推察してください。その上で、単なる答えではなく、ユーザーが「なるほど！」と気づきを得られるような、核心を突いたヒントや別の視点を提供してください。"""
+
+        return f"""あなたは、ユーザーの長期的な学習履歴も理解している、パーソナルな家庭教師AIです。
+
+# 応答形式のルール
+- 応答は必ずMarkdown形式で記述してください。
+- 見出し（`###`）、太字（`**...**`）、箇条書き（`- ...`）などを活用し、視覚的に分かりやすい説明を心がけてください。
+- 数式は、ディスプレイ数式なら `$$ ... $$`、インライン数式なら `$...$` を使って記述してください。
+- コードや計算過程など、数式ではないが整形して見せたいテキストは、インラインコード（`...`）やコードブロック（```...```）を使用できます。
+- 重要: コードブロックの中に数式を記述しないでください。数式は必ず独立させてください。
+
+# 長期的な学習状況（長期記憶）
+{long_term_context}
+
+# 現在のセッションの状況（短期記憶）
+## ユーザーが取り組んでいる問題
+{self.problem_context_text}
+## これまでの会話の要約
+{self.chat_summary}
+## ユーザーの最近の様子（システムによる定点観測）
+{observation_str}
+## ユーザーの最近の独り言（音声認識より）
+{monologue_str}
+## 直近の会話（最後の5往復程度）
+{history_str}
+
+# ユーザーからの現在の質問
+「{user_query}」
+
+# あなたのタスク
+上記のすべての情報を統合し、ユーザーの思考プロセスや詰まっている点を深く推察してください。
+その上で、単なる答えではなく、ユーザーが「なるほど！」と気づきを得られるような、核心を突いたヒントや別の視点を提供してください。
+"""
 
     def build_prompt_parts_for_command(self, user_command: str, chat_history: List[Dict], monologue_history: List[str], long_term_context: str) -> Optional[List[Any]]:
-        if self.triggered_image is None: return None
+        """
+        音声コマンドに応答するため、テキストと画像を組み合わせたプロンプトパーツを生成する。
+        """
+        if self.triggered_image is None:
+            print("エラー: コマンド用のトリガー画像が設定されていません。")
+            return None
+
         history_str = "\n".join([f"- {msg['role']}: {msg['content']}" for msg in chat_history])
         monologue_str = "\n".join([f"- {m}" for m in monologue_history]) or "なし"
-        text_prompt = f"""あなたは、ユーザーの状況を深く理解する家庭教師AIです。\nユーザーから「{user_command}」という音声コマンドを受け取りました。\n添付されている画像は、そのコマンドが発せられた瞬間のユーザーの机の様子です。\n\n# 応答形式のルール\n- 応答は必ずMarkdown形式で記述してください。\n- 数式は$$...$$や$...$で囲んでください。\n\n# 参考情報\n- **長期的な学習状況:** {long_term_context}\n- **ユーザーが取り組んでいる問題の概要:** {self.problem_context_text}\n- **直近の独り言:** {monologue_str}\n- **直近の会話:** {history_str}\n\n# あなたのタスク\n添付された画像と上記の参考情報を最優先で分析し、ユーザーの意図を汲み取って、コマンドに的確に応答してください。"""
+
+        text_prompt = f"""
+あなたは、ユーザーの状況を深く理解する家庭教師AIです。
+ユーザーから「{user_command}」という音声コマンドを受け取りました。
+添付されている画像は、そのコマンドが発せられた瞬間のユーザーの机の様子です。
+
+# 応答形式のルール
+- 応答は必ずMarkdown形式で記述してください。
+- 数式は$$...$$や$...$で囲んでください。
+
+# 参考情報
+- **長期的な学習状況:** {long_term_context}
+- **ユーザーが取り組んでいる問題の概要:** {self.problem_context_text}
+- **これまでの会話の要約:** {self.chat_summary}
+- **直近の独り言:** {monologue_str}
+- **直近の会話:** {history_str}
+
+# あなたのタスク
+添付された画像と上記の参考情報を最優先で分析し、ユーザーの意図を汲み取って、コマンドに的確に応答してください。
+"""
         return [text_prompt, self.triggered_image]

--- a/src/core/database_manager.py
+++ b/src/core/database_manager.py
@@ -1,5 +1,3 @@
-# src/core/database_manager.py スレッド名の自動設定
-
 import sqlite3
 import os
 from datetime import datetime, timedelta
@@ -237,3 +235,12 @@ class DatabaseManager:
         conn.commit()
         conn.close()
         print(f"セッションID {session_id} のタイトルを更新しました: {new_title}")
+
+    def update_session_summary(self, session_id: int, summary: str):
+        """指定されたセッションの会話要約を更新する"""
+        conn = self._get_connection()
+        cursor = conn.cursor()
+        cursor.execute("UPDATE sessions SET chat_summary = ? WHERE id = ?", (summary, session_id))
+        conn.commit()
+        conn.close()
+        print(f"セッションID {session_id} の要約を更新しました。")

--- a/src/core/database_worker.py
+++ b/src/core/database_worker.py
@@ -1,5 +1,3 @@
-# src/core/database_worker.py　スレッド名自動設定
-
 from PySide6.QtCore import QThread, Signal, Slot
 from typing import Any
 from .database_manager import DatabaseManager
@@ -57,8 +55,13 @@ class DatabaseWorker(QThread):
         """セッションタイトル更新タスクをキューに入れる"""
         self.tasks.append((self.db_manager.update_session_title, (session_id, new_title), {}))
 
+    @Slot(int, str)
+    def update_session_summary(self, session_id: int, summary: str):
+        """セッション要約更新タスクをキューに入れる"""
+        self.tasks.append((self.db_manager.update_session_summary, (session_id, summary), {}))
+
     def stop(self):
         """スレッドを安全に停止させる"""
         print("データベースワーカーを停止します...")
         self._is_running = False
-        # wait()は呼び出し元のMainWindowで行う
+        self.wait()

--- a/src/ui/settings_dialog.py
+++ b/src/ui/settings_dialog.py
@@ -144,7 +144,7 @@ class SettingsDialog(QDialog):
             self.add_default_models()
 
     def add_default_models(self):
-        default_models = ["gemini-1.5-flash", "gemini-1.5-pro"]
+        default_models = ["gemini-2.5-flash", "gemini-2.5-flash"]
         for selector in [self.keyword_model_selector, self.main_response_model_selector, self.vision_model_selector]:
             selector.addItems(default_models)
 


### PR DESCRIPTION
これまでのあらすじ」を把握した上で応答を生成できます。

要約のタイミング
ユーザーの発言後: ユーザーが質問を送信するたびに、会話が要約の条件（ユーザー発言5回以上）を満たしているかチェックし、バックグラウンドで要約生成を開始します。AIの応答を待つ間に要約処理が進むため、ユーザー体験を損ないません。
セッション切り替え時: 古いセッションの最終的なまとめとして要約を生成・保存します。
アプリ終了時: 現在のセッションの最終状態を要約として保存します。

DBとの連携: 生成された要約はsessionsテーブルに保存されるため、次回アプリケーションを起動して同じセッションを選択した際に、以前の要約を読み込んで文脈を引き継ぐことができます。

プロンプトの工夫: 直近の会話（最後の5往復など）はそのままプロンプトに含め、それ以前の会話は要約で代替することで、情報の鮮度と網羅性を両立させています。

また、セッション命名は、セッション切り替えに時に実行していたが、GeminiAPIの呼び出し回数を減らすため、ユーザーのセッション切り替えが落ち着て２秒後にセッション命名をするように変更。
